### PR TITLE
Docker Hub multi-tag setup readme hack

### DIFF
--- a/0.9.2/README.md
+++ b/0.9.2/README.md
@@ -1,0 +1,5 @@
+# Microsoft Azure CLI Docker Image 
+
+This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
+
+    $ docker run -it microsoft/azure-cli

--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-# Microsoft Azure CLI Docker Image 
-
-This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
-
-    $ docker run -it microsoft/azure-cli
+0.9.2/README.md


### PR DESCRIPTION
This symbolic link hack is required for Docker image description to show up in Docker Hub.

* Actual README.md file must exist next to a dockerfile that gets built by Docker Hub (preferably latest one)
* Repo must have a single README.md (to keep the repo clean and eliminate duplication)
* Every time README is moved, symlink in the root (`./README.md`)must be updated (e.g. `ln -s 0.9.2/README.md ./README.md`)
