### PR TITLE
Add --no-install-recommends to apt-get

### DIFF
--- a/0.9.2/Dockerfile
+++ b/0.9.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
 RUN apt-get update && \
-        apt-get -qqy install -y nodejs-legacy npm && \
+        apt-get -qqy install --no-install-recommends nodejs-legacy npm && \
         sudo npm install --global azure-cli@0.9.2 && \
         azure


### PR DESCRIPTION
Reduces image size by 86 MB (from 456M to 370M) by not installing the 'recommended' nodejs dependencies in `apt-get`.

cc: @kmouss 

```
azure-cli                           smaller                   d9c4d7b89153        41 seconds ago      370.3 MB
microsoft/azure-cli                 latest                    08ab4049efd8        42 minutes ago      456.6 MB
```
Signed-off-by: Ahmet Alp Balkan