### PR TITLE
Change to Entrypoint

### DIFF
--- a/0.9.2/Dockerfile
+++ b/0.9.2/Dockerfile
@@ -3,4 +3,8 @@ FROM ubuntu:14.04
 RUN apt-get update && \
         apt-get -qqy install --no-install-recommends nodejs-legacy npm && \
         sudo npm install --global azure-cli@0.9.2 && \
-        azure
+	azure
+
+VOLUME /root/.azure
+
+ENTRYPOINT ["/usr/local/bin/azure"]

--- a/0.9.2/README.md
+++ b/0.9.2/README.md
@@ -2,4 +2,8 @@
 
 This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
 
-    $ docker run -it microsoft/azure-cli
+    $ docker run -v ~/.azure:/root/.azure -it microsoft/azure-cli [OPTIONS]
+
+You can use this as a shell alias as well:
+    $ alias azure='docker run -v ~/.azure:/root/.azure -it microsoft/azure-cli'
+    $ azure [OPTIONS]


### PR DESCRIPTION
In order to support using the docker container as a shell alias, use the `ENTRYPOINT` stanza in the Dockerfile. Updated `README.md` to reflect the change and new usage.