### PR TITLE
Remove initial call to azure

### DIFF
--- a/0.9.5/Dockerfile
+++ b/0.9.5/Dockerfile
@@ -2,5 +2,4 @@ FROM ubuntu:14.04
 
 RUN apt-get update && \
         apt-get -qqy install --no-install-recommends nodejs-legacy npm && \
-        sudo npm install --global azure-cli@0.9.5 && \
-        azure
+        sudo npm install --global azure-cli@0.9.5


### PR DESCRIPTION
Apparently there's no first-time run performance penalty in the CLI anymore, so removing.
cc: @devigned pls merge at your discretion.