### PR TITLE
change 0.9.14 to use node4 lts

### DIFF
--- a/0.9.14/Dockerfile
+++ b/0.9.14/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:jessie
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV AZURE_CLI_VERSION "0.9.14"
-ENV NODEJS_APT_ROOT "node_5.x"
-ENV NODEJS_VERSION "5.4.1"
+ENV NODEJS_APT_ROOT "node_4.x"
+ENV NODEJS_VERSION "4.2.4"
 
 RUN apt-get update -qq && \
     apt-get install -qqy --no-install-recommends\


### PR DESCRIPTION
Per https://github.com/Azure/azure-cli-docker/pull/24#issuecomment-173655959

Changing node version in the Dockerfile to the latest of the 4.x.x series (LTS), which is 4.2.5.