### PR TITLE
Add 0.10.18, 0.10.19, and 0.10.20 Versions With Additional Updates

### DIFF
--- a/0.10.18/Dockerfile
+++ b/0.10.18/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update -qq && \
       rlwrap \
       vim \
       nano \
-      jq
+      jq \
+      zip
 
 #Run as non-root node user
 WORKDIR /home/node/

--- a/0.10.18/Dockerfile
+++ b/0.10.18/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:6-slim
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV AZURE_CLI_VERSION="0.10.18" \
+    EDITOR=vim
+
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends \
+      apt-transport-https \
+      build-essential \
+      curl \
+      ca-certificates \
+      git \
+      lsb-release \
+      python-all \
+      rlwrap \
+      vim \
+      nano \
+      jq
+
+#Run as non-root node user
+WORKDIR /home/node/
+RUN mkdir -p /home/node/app /home/node/.npm-global && \
+    chown -R node:node /home/node
+ENV PATH=/home/node/.npm-global/bin:$PATH \
+    NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+USER node
+RUN npm install --global azure-cli@${AZURE_CLI_VERSION} && \
+    azure --completion >> ~/azure.completion.sh && \
+    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
+    azure
+
+RUN azure config mode arm
+
+ENTRYPOINT ["azure"]

--- a/0.10.18/README.md
+++ b/0.10.18/README.md
@@ -1,0 +1,5 @@
+# Microsoft Azure CLI Docker Image
+
+This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
+
+    $ docker run -it microsoft/azure-cli

--- a/0.10.19/Dockerfile
+++ b/0.10.19/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:6-slim
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV AZURE_CLI_VERSION="0.10.19" \
+    EDITOR=vim
+
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends \
+      apt-transport-https \
+      build-essential \
+      curl \
+      ca-certificates \
+      git \
+      lsb-release \
+      python-all \
+      rlwrap \
+      vim \
+      nano \
+      jq
+
+#Run as non-root node user
+WORKDIR /home/node/
+RUN mkdir -p /home/node/app /home/node/.npm-global && \
+    chown -R node:node /home/node
+ENV PATH=/home/node/.npm-global/bin:$PATH \
+    NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+USER node
+RUN npm install --global azure-cli@${AZURE_CLI_VERSION} && \
+    azure --completion >> ~/azure.completion.sh && \
+    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
+    azure
+
+RUN azure config mode arm
+
+ENTRYPOINT ["azure"]

--- a/0.10.19/Dockerfile
+++ b/0.10.19/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update -qq && \
       rlwrap \
       vim \
       nano \
-      jq
+      jq \
+      zip
 
 #Run as non-root node user
 WORKDIR /home/node/

--- a/0.10.19/README.md
+++ b/0.10.19/README.md
@@ -1,0 +1,5 @@
+# Microsoft Azure CLI Docker Image
+
+This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
+
+    $ docker run -it microsoft/azure-cli

--- a/0.10.20/Dockerfile
+++ b/0.10.20/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:6-slim
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV AZURE_CLI_VERSION="0.10.20" \
+    EDITOR=vim
+
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends \
+      apt-transport-https \
+      build-essential \
+      curl \
+      ca-certificates \
+      git \
+      lsb-release \
+      python-all \
+      rlwrap \
+      vim \
+      nano \
+      jq
+
+#Run as non-root node user
+WORKDIR /home/node/
+RUN mkdir -p /home/node/app /home/node/.npm-global && \
+    chown -R node:node /home/node
+ENV PATH=/home/node/.npm-global/bin:$PATH \
+    NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+USER node
+RUN npm install --global azure-cli@${AZURE_CLI_VERSION} && \
+    azure --completion >> ~/azure.completion.sh && \
+    echo 'source ~/azure.completion.sh' >> ~/.bashrc && \
+    azure
+
+RUN azure config mode arm
+
+ENTRYPOINT ["azure"]

--- a/0.10.20/Dockerfile
+++ b/0.10.20/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update -qq && \
       rlwrap \
       vim \
       nano \
-      jq
+      jq \
+      zip
 
 #Run as non-root node user
 WORKDIR /home/node/

--- a/0.10.20/README.md
+++ b/0.10.20/README.md
@@ -1,0 +1,5 @@
+# Microsoft Azure CLI Docker Image
+
+This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
+
+    $ docker run -it microsoft/azure-cli


### PR DESCRIPTION
Fixes: #27, #56, #58, #59

Uses node:6-slim image as base
Installs `zip` package
Runs Debian based image and as user `node` and not root
Uses `azure` as ENTRYPOINT 