### PR TITLE
Update README.md: Remove leading `$` from terminal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Update
 Please use the docker for [Azure CLI 2.0](https://hub.docker.com/_/microsoft-azure-cli).
 
-    $ docker run -it mcr.microsoft.com/azure-cli
+```
+docker run -it mcr.microsoft.com/azure-cli
+```
 
 ## Microsoft Azure CLI Docker Image (Deprecated)
 
 This Docker image has Microsoft Azure CLI installed and prepared. To run it, execute:
 
-    $ docker run -it microsoft/azure-cli
+```
+docker run -it microsoft/azure-cli
+```


### PR DESCRIPTION
## Why

Copying the commands via the GitHub UI will include the `$` which won't work when pasting it to a terminal.

Removing the leading `$` will improve the UX and enables developers to easily copy and paste the commands